### PR TITLE
fix candygrams

### DIFF
--- a/R/give_candygrams.R
+++ b/R/give_candygrams.R
@@ -30,7 +30,7 @@ give_candygrams <- function(person, number,
   number <- str_to_title(as.english(number))
 
 
-  glue::glue("{number} for {person}.")
+  glue::glue("{number} for {person}.{extra_message}")
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also give extra commentary to your announcement:
 ``` r
 give_candygrams("Taylor Zimmerman", 2, 
                 extra_message = "Merry Christmas!")
-#> Two for Taylor Zimmerman.
+#> Two for Taylor Zimmerman.Merry Christmas!
 ```
 
 Some special cases trigger automatic extra commentary or special
@@ -100,10 +100,10 @@ behavior:
 
 ``` r
 give_candygrams("Glen Coco", 4)
-#> Four for Glen Coco.
+#> Four for Glen Coco.You go, Glen Coco!
 ```
 
 ``` r
 give_candygrams("Gretchen Weiners", 4)
-#> [1] "None for Grethen Weiners."
+#> None for Gretchen Weiners.
 ```


### PR DESCRIPTION
Fixed the candygrams function to contain the extra_message argument in the return